### PR TITLE
Fix: correct default output filenames using -o param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+md5collgen

--- a/main.cpp
+++ b/main.cpp
@@ -152,8 +152,8 @@ int main(int argc, char** argv)
 
     uint32 IV[4] = { MD5IV[0], MD5IV[1], MD5IV[2], MD5IV[3] };
 
-    string outfn1 = "msg1.bin";
-    string outfn2 = "msg2.bin";
+    string outfn1 = "";
+    string outfn2 = "";
     string ihv {""};
     string prefixfn;
     bool prefixfile = false;
@@ -173,6 +173,11 @@ int main(int argc, char** argv)
         Timer runtime;
 
         int pos{1};
+
+        if (argc == 1) {
+            print_help();
+            return 1;
+        }
 
         for (auto i = 1; i < argc; i ++) {
             std::string_view arg{argv[i]};
@@ -239,7 +244,7 @@ int main(int argc, char** argv)
         if (testall)
             test_all();
 
-        if (prefixfile)
+        if (prefixfile && !outfn1.size())
         {
             unsigned l = prefixfn.size();
             if (l >= 4 && prefixfn[l-4]=='.' && prefixfn[l-3]!='.' && prefixfn[l-2]!='.' && prefixfn[l-1]!='.')


### PR DESCRIPTION
When using the program with -p and -o args, for example:
```
> ./md5collgen-github -p prefix.txt -o fn1 fn2
MD5 collision generator v1.5
by Marc Stevens (http://www.win.tue.nl/hashclash/)

Using output filenames: 'prefix_msg1_5.txt' and 'prefix_msg2_5.txt'
Using prefixfile: 'prefix.txt'
Using initial value: 25eb04c1c36ff3ba0311528bbf9d9ea1

Generating first block: .........................................................................................................................................................................
Generating second block: S10.
Running time: 32.930783 s

```
it outputs `prefix_msg1_5.txt` and `prefix_msg2_5.txt`. 
However, the one I downloaded from [seedlabs](https://seedsecuritylabs.org/Labs_20.04/Crypto/Crypto_MD5_Collision/) outputs like this:
```
> ./md5collgen -p prefix.txt -o fn1 fn2 
MD5 collision generator v1.5
by Marc Stevens (http://www.win.tue.nl/hashclash/)

Using output filenames: 'fn1' and 'fn2'
Using prefixfile: 'prefix.txt'
Using initial value: 25eb04c1c36ff3ba0311528bbf9d9ea1

Generating first block: ....
Generating second block: S10...........
Running time: 1.27279 s
```
which is acceptable.

The 2 commits fix this problem as well as add `.gitignore` to avoid object files and executable adding into git. 
